### PR TITLE
Remove file existence check for `.env`

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -15,7 +15,6 @@ from utils.core import get_env, get_random_quote # bot standard functions
 
 # validate all mandatory files exist before starting
 assert os.path.isfile('../utils/logging_config.ini') # Logs config file
-assert os.path.isfile('.env')                       # environment variables file
 
 # Instantiate logging in accordance with config file
 fileConfig('../utils/logging_config.ini')


### PR DESCRIPTION
Hi! I'm using your libraries to run the bot in a Docker container, and I don't want to use .env files because that will include my token in the image, which is public. Instead, I'm using environment variables. Your code already uses `os.get_env(..)` in `utils/core.py`, which is great. The bot runs fine without the .env file, so this PR removes the assertion on line 17.

https://github.com/JasonFreeberg/bobby-b-on-azure